### PR TITLE
Prevent errors from file paths with spaces

### DIFF
--- a/append_with_date.sh
+++ b/append_with_date.sh
@@ -12,6 +12,6 @@ name=${file%.*}
 extension=${file#*.}
 output=${name}${today}.$extension
 
-cp $file $output
+cp "$file" "$output"
 echo "File is now called $output"
 

--- a/char_word_count.sh
+++ b/char_word_count.sh
@@ -5,20 +5,20 @@ echo -n "Enter a text or csv file: "
 read file
 
 # If the file is a text file, returns the character and word counts
-if [ ${file: -4} == ".txt" ]
+if [ "${file: -4}" == ".txt" ]
 then
   echo "Text file entered..."
   echo -n "Number of characters: " 
-  wc -m < $file
+  wc -m < "$file"
   echo -n "Number of words: "
-  wc -w < $file
-elif [ ${file: -4} == ".csv" ]
+  wc -w < "$file"
+elif [ "${file: -4}" == ".csv" ]
 then
   echo "CSV file entered..."
   echo -n "Number of characters: "
-  wc -m < $file
+  wc -m < "$file"
   echo -n "Number of words: "
-  wc -w < $file
+  wc -w < "$file"
   echo -n "Number of comma separated values: "
-  grep -o "," $file | wc -l
+  grep -o "," "$file" | wc -l
 fi


### PR DESCRIPTION
String expansion occurs *before* each line is split into positional arguments: if the values of `file` or `output` contain a space, they will be treated as two separate arguments, and the `cp` command will not behave as expected.

(Variable assignments are parsed slightly differently than commands, so lines 10-13 should be fine with or without quotes.)